### PR TITLE
Services use Guids 

### DIFF
--- a/PubHub/PubHub.Common/Services/BookService.cs
+++ b/PubHub/PubHub.Common/Services/BookService.cs
@@ -21,8 +21,6 @@ namespace PubHub.Common.Services
             };
         }
 
-        // TODO (JBN): Change to GUIDs instead of int when that has been updated.
-
         /// <summary>
         /// Calls the API enpoint to retrieve all books through the <see cref="BookInfoModel"/> filtered on the searchQuery.
         /// </summary>
@@ -60,19 +58,20 @@ namespace PubHub.Common.Services
                 return null!;
             }
         }
+
         /// <summary>
         /// Calls the API end point for retrieving <see cref="BookInfoModel">, to use in the client applications.
         /// </summary>
         /// <param name="bookId">Id of the book we want information about.</param>
         /// <returns>A <see cref="BookInfoModel"/> with a book's information.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<BookInfoModel?> GetBook(int bookId)
+        public async Task<BookInfoModel?> GetBook(Guid bookId)
         {
             try
             {
-                if (bookId <= 0)
-                    throw new ArgumentOutOfRangeException($"The book Id wasn't a valid Id: {bookId}");
+                if (bookId == Guid.Empty)
+                    throw new ArgumentException($"The book Id wasn't a valid Id: {bookId}");
 
                 HttpResponseMessage response = await Client.GetAsync($"books/{bookId}");
                 string content = await response.Content.ReadAsStringAsync();
@@ -147,15 +146,15 @@ namespace PubHub.Common.Services
         /// <param name="bookId">The id of the book being updated.</param>
         /// <param name="bookUpdateModel">The <see cref="BookUpdateModel"/> holding the updated values.</param>
         /// <returns>A status telling if a book was successfully updated in the database.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceInstanceResult<BookUpdateModel>> UpdateBook(int bookId, BookUpdateModel bookUpdateModel)
+        public async Task<ServiceInstanceResult<BookUpdateModel>> UpdateBook(Guid bookId, BookUpdateModel bookUpdateModel)
         {
             try
             {
-                if (bookId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {bookId}");
+                if (bookId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {bookId}");
 
                 if (bookUpdateModel == null)
                     throw new ArgumentNullException($"The User update model wasn't valid: {bookUpdateModel?.Title}");
@@ -193,14 +192,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="bookId">The Id of the book who needs to be soft-deleted.</param>
         /// <returns>A <see cref="ServiceResult"/> telling if the request was successful.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceResult> DeleteUser(int bookId)
+        public async Task<ServiceResult> DeleteUser(Guid bookId)
         {
             try
             {
-                if (bookId <= 0)
-                    throw new ArgumentOutOfRangeException($"The book Id wasn't a valid Id: {bookId}");
+                if (bookId == Guid.Empty)
+                    throw new ArgumentException($"The book Id wasn't a valid Id: {bookId}");
 
                 HttpResponseMessage response = await Client.DeleteAsync($"books/{bookId}");
                 string content = await response.Content.ReadAsStringAsync();

--- a/PubHub/PubHub.Common/Services/IBookService.cs
+++ b/PubHub/PubHub.Common/Services/IBookService.cs
@@ -5,9 +5,9 @@ namespace PubHub.Common.Services
     public interface IBookService
     {
         Task<List<BookInfoModel>> GetBooks(BookQuery queryOptions);
-        Task<BookInfoModel?> GetBook(int bookId);
+        Task<BookInfoModel?> GetBook(Guid bookId);
         Task<ServiceInstanceResult<BookCreateModel>> AddBook(BookCreateModel bookCreateModel);
-        Task<ServiceInstanceResult<BookUpdateModel>> UpdateBook(int bookId, BookUpdateModel bookUpdateModel);
-        Task<ServiceResult> DeleteUser(int bookId);
+        Task<ServiceInstanceResult<BookUpdateModel>> UpdateBook(Guid bookId, BookUpdateModel bookUpdateModel);
+        Task<ServiceResult> DeleteUser(Guid bookId);
     }
 }

--- a/PubHub/PubHub.Common/Services/IPublisherService.cs
+++ b/PubHub/PubHub.Common/Services/IPublisherService.cs
@@ -12,9 +12,9 @@ namespace PubHub.Common.Services
     public interface IPublisherService
     {
         Task<ServiceInstanceResult<PublisherCreateModel>> AddPublisher(PublisherCreateModel publisherCreateModel);
-        Task<PublisherInfoModel?> GetPublisherInfo(int publisherId);
-        Task<List<BookInfoModel>> GetPublisherBooks(int publisherId);
-        Task<ServiceInstanceResult<PublisherUpdateModel>> UpdatePublisher(int publisherId, PublisherUpdateModel publisherUpdateModel);
-        Task<ServiceResult> DeletePublisher(int publisherId);
+        Task<PublisherInfoModel?> GetPublisherInfo(Guid publisherId);
+        Task<List<BookInfoModel>> GetPublisherBooks(Guid publisherId);
+        Task<ServiceInstanceResult<PublisherUpdateModel>> UpdatePublisher(Guid publisherId, PublisherUpdateModel publisherUpdateModel);
+        Task<ServiceResult> DeletePublisher(Guid publisherId);
     }
 }

--- a/PubHub/PubHub.Common/Services/IUserService.cs
+++ b/PubHub/PubHub.Common/Services/IUserService.cs
@@ -6,10 +6,10 @@ namespace PubHub.Common.Services
     public interface IUserService
     {
         Task<ServiceInstanceResult<UserCreateModel>> AddUser(UserCreateModel userCreateModel);
-        Task<UserInfoModel?> GetUserInfo(int userId);
-        Task<List<BookInfoModel>> GetUserBooks(int userId);
-        Task<ServiceInstanceResult<UserUpdateModel>> UpdateUser(int userId, UserUpdateModel userUpdateModel);
-        Task<ServiceResult> DeleteUser(int userId);
-        Task<ServiceResult> SuspendUser(int userId);
+        Task<UserInfoModel?> GetUserInfo(Guid userId);
+        Task<List<BookInfoModel>> GetUserBooks(Guid userId);
+        Task<ServiceInstanceResult<UserUpdateModel>> UpdateUser(Guid userId, UserUpdateModel userUpdateModel);
+        Task<ServiceResult> DeleteUser(Guid userId);
+        Task<ServiceResult> SuspendUser(Guid userId);
     }
 }

--- a/PubHub/PubHub.Common/Services/PublisherService.cs
+++ b/PubHub/PubHub.Common/Services/PublisherService.cs
@@ -23,8 +23,6 @@ namespace PubHub.Common.Services
             };
         }
 
-        // TODO (JBN): Change to GUIDs instead of int when that has been updated.
-
         /// <summary>
         /// Calls the API endpoint for adding a <see cref="PublisherCreateModel"/> to the database.
         /// </summary>
@@ -72,14 +70,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="publisherId">The Id of the publisher who's books needs retrieval.</param>
         /// <returns>A list of <see cref="BookInfoModel"/></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<List<BookInfoModel>> GetPublisherBooks(int publisherId)
+        public async Task<List<BookInfoModel>> GetPublisherBooks(Guid publisherId)
         {
             try
             {
-                if (publisherId <= 0)
-                    throw new ArgumentOutOfRangeException($"The publisher Id wasn't a valid Id: {publisherId}");
+                if (publisherId == Guid.Empty)
+                    throw new ArgumentException($"The publisher Id wasn't a valid Id: {publisherId}");
 
                 HttpResponseMessage response = await Client.GetAsync($"publishers/{publisherId}/books");
                 string content = await response.Content.ReadAsStringAsync();
@@ -111,14 +109,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="publisherId">Id of the publisher wanting information about.</param>
         /// <returns>A <see cref="PublisherInfoModel"/> with the users information.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<PublisherInfoModel?> GetPublisherInfo(int publisherId)
+        public async Task<PublisherInfoModel?> GetPublisherInfo(Guid publisherId)
         {
             try
             {
-                if (publisherId <= 0)
-                    throw new ArgumentOutOfRangeException($"The publisher Id wasn't a valid Id: {publisherId}");
+                if (publisherId == Guid.Empty)
+                    throw new ArgumentException($"The publisher Id wasn't a valid Id: {publisherId}");
 
                 HttpResponseMessage response = await Client.GetAsync($"publishers/{publisherId}");
                 string content = await response.Content.ReadAsStringAsync();
@@ -151,15 +149,15 @@ namespace PubHub.Common.Services
         /// <param name="publisherId">The id of the publisher being updated.</param>
         /// <param name="publisherUpdateModel">The <see cref="PublisherUpdateModel"/> holding the updated values.</param>
         /// <returns>A <see cref="ServiceResult"/> on how the request was handled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceInstanceResult<PublisherUpdateModel>> UpdatePublisher(int publisherId, PublisherUpdateModel publisherUpdateModel)
+        public async Task<ServiceInstanceResult<PublisherUpdateModel>> UpdatePublisher(Guid publisherId, PublisherUpdateModel publisherUpdateModel)
         {
             try
             {
-                if (publisherId <= 0)
-                    throw new ArgumentOutOfRangeException($"The publisher Id wasn't a valid Id: {publisherId}");
+                if (publisherId == Guid.Empty)
+                    throw new ArgumentException($"The publisher Id wasn't a valid Id: {publisherId}");
 
                 if (publisherUpdateModel == null)
                     throw new ArgumentNullException($"The publisher update model wasn't valid: {publisherUpdateModel?.Name}");
@@ -197,14 +195,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="publisherId">The Id of the publisher who needs to be soft-deleted.</param>
         /// <returns>A <see cref="ServiceResult"/> on how the request was handled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceResult> DeletePublisher(int publisherId)
+        public async Task<ServiceResult> DeletePublisher(Guid publisherId)
         {
             try
             {
-                if (publisherId <= 0)
-                    throw new ArgumentOutOfRangeException($"The publisher Id wasn't a valid Id: {publisherId}");
+                if (publisherId == Guid.Empty)
+                    throw new ArgumentException($"The publisher Id wasn't a valid Id: {publisherId}");
 
                 HttpResponseMessage response = await Client.DeleteAsync($"publishers/{publisherId}");
                 string content = await response.Content.ReadAsStringAsync();

--- a/PubHub/PubHub.Common/Services/UserService.cs
+++ b/PubHub/PubHub.Common/Services/UserService.cs
@@ -23,8 +23,6 @@ namespace PubHub.Common.Services
             };
         }
 
-        // TODO (JBN): Change to GUIDs instead of int when that has been updated.
-
         /// <summary>
         /// Calls the API endpoint for adding a <see cref="UserCreateModel"/> to the database.
         /// </summary>
@@ -72,14 +70,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="userId">Id of the user wanting information about.</param>
         /// <returns>A <see cref="UserInfoModel"/> with the users information.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<UserInfoModel?> GetUserInfo(int userId)
+        public async Task<UserInfoModel?> GetUserInfo(Guid userId)
         {
             try
             {
-                if (userId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {userId}");
+                if (userId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {userId}");
 
                 HttpResponseMessage response = await Client.GetAsync($"users/{userId}");
                 string content = await response.Content.ReadAsStringAsync();
@@ -111,14 +109,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="userId">The Id of the user who's books needs retrieval.</param>
         /// <returns>A list of <see cref="BookInfoModel"/></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<List<BookInfoModel>> GetUserBooks(int userId)
+        public async Task<List<BookInfoModel>> GetUserBooks(Guid userId)
         {
             try
             {
-                if (userId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {userId}");
+                if (userId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {userId}");
 
                 HttpResponseMessage response = await Client.GetAsync($"users/{userId}/books");
                 string content = await response.Content.ReadAsStringAsync();
@@ -151,15 +149,15 @@ namespace PubHub.Common.Services
         /// <param name="userId">The id of the user being updated.</param>
         /// <param name="userUpdateModel">The <see cref="UserUpdateModel"/> holding the updated values.</param>
         /// <returns>A <see cref="ServiceResult"/> on how the request was handled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceInstanceResult<UserUpdateModel>> UpdateUser(int userId, UserUpdateModel userUpdateModel)
+        public async Task<ServiceInstanceResult<UserUpdateModel>> UpdateUser(Guid userId, UserUpdateModel userUpdateModel)
         {
             try
             {
-                if (userId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {userId}");
+                if (userId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {userId}");
 
                 if (userUpdateModel == null)
                     throw new ArgumentNullException($"The User update model wasn't valid: {userUpdateModel?.Name}");
@@ -197,14 +195,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="userId">The Id of the user who needs to be soft-deleted.</param>
         /// <returns>A <see cref="ServiceResult"/> on how the request was handled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceResult> DeleteUser(int userId)
+        public async Task<ServiceResult> DeleteUser(Guid userId)
         {
             try
             {
-                if (userId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {userId}");
+                if (userId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {userId}");
 
                 HttpResponseMessage response = await Client.DeleteAsync($"users/{userId}");
                 string content = await response.Content.ReadAsStringAsync();
@@ -232,14 +230,14 @@ namespace PubHub.Common.Services
         /// </summary>
         /// <param name="userId">The Id of the user who needs to have their account type as suspended.</param>
         /// <returns>A <see cref="ServiceResult"/> on how the request was handled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <exception cref="NullReferenceException"></exception>
-        public async Task<ServiceResult> SuspendUser(int userId)
+        public async Task<ServiceResult> SuspendUser(Guid userId)
         {
             try
             {
-                if (userId <= 0)
-                    throw new ArgumentOutOfRangeException($"The user Id wasn't a valid Id: {userId}");
+                if (userId == Guid.Empty)
+                    throw new ArgumentException($"The user Id wasn't a valid Id: {userId}");
 
                 HttpResponseMessage response = await Client.DeleteAsync($"users/{userId}/suspend-user");
                 string content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
- [~] Modified the methods on all the services to use `Guid` instead of `int` on the ids to match the new structure on the developer branch; as well as the exceptions being thrown `if (id == Guid.Empty)`