### PR TITLE
Setup projects for unit testing

### DIFF
--- a/PubHub/PubHub.API/Controllers/PublishersController.cs
+++ b/PubHub/PubHub.API/Controllers/PublishersController.cs
@@ -160,7 +160,7 @@ namespace PubHub.API.Controllers
         public async Task<IResult> GetPublishersAsync([FromQuery] PublisherQuery query)
         {
             var publishers = await _context.Set<Publisher>()
-                 .Include(u => u.Account)
+                .Include(p => p.Account)
                 .Filter(query)
                 .Select(p => new PublisherInfoModel()
                 {

--- a/PubHub/PubHub.API/Domain/PubHubContext.cs
+++ b/PubHub/PubHub.API/Domain/PubHubContext.cs
@@ -19,6 +19,11 @@ namespace PubHub.API.Domain
 
         public PubHubContext(DbContextOptions<PubHubContext> options) : base(options) { }
 
+        /// <summary>
+        /// Whether to apply the database seed data or not. Used for testing purposes and when working with migrations.
+        /// </summary>
+        public bool ApplySeed { get; init; } = true;
+
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)
@@ -322,30 +327,33 @@ namespace PubHub.API.Domain
             #endregion
 
             #region Seeding
-            var accessTypes = new AccessTypeSeed();
-            var accountTypes = new AccountTypeSeed();
-            var accounts = new AccountSeed(accountTypes);
-            var authors = new AuthorSeed();
-            var contentTypes = new ContentTypeSeed();
-            var publishers = new PublisherSeed(accounts);
-            var genres = new GenreSeed();
-            var books = new BookSeed(contentTypes, publishers);
-            var bookAuthors = new BookAuthorSeed(books, authors);
-            var bookGenres = new BookGenreSeed(books, genres);
-            var operators = new OperatorSeed(accounts);
-            var users = new UserSeed(accounts);
-            
-            builder.ApplyConfiguration(accessTypes);
-            builder.ApplyConfiguration(accountTypes);
-            builder.ApplyConfiguration(accounts);
-            builder.ApplyConfiguration(authors);
-            builder.ApplyConfiguration(contentTypes);
-            builder.ApplyConfiguration(publishers);
-            builder.ApplyConfiguration(genres);
-            builder.ApplyConfiguration(books);
-            builder.ApplyConfiguration(bookAuthors);
-            builder.ApplyConfiguration(bookGenres);
-            builder.ApplyConfiguration(users);
+            if (ApplySeed)
+            {
+                var accessTypes = new AccessTypeSeed();
+                var accountTypes = new AccountTypeSeed();
+                var accounts = new AccountSeed(accountTypes);
+                var authors = new AuthorSeed();
+                var contentTypes = new ContentTypeSeed();
+                var publishers = new PublisherSeed(accounts);
+                var genres = new GenreSeed();
+                var books = new BookSeed(contentTypes, publishers);
+                var bookAuthors = new BookAuthorSeed(books, authors);
+                var bookGenres = new BookGenreSeed(books, genres);
+                var operators = new OperatorSeed(accounts);
+                var users = new UserSeed(accounts);
+
+                builder.ApplyConfiguration(accessTypes);
+                builder.ApplyConfiguration(accountTypes);
+                builder.ApplyConfiguration(accounts);
+                builder.ApplyConfiguration(authors);
+                builder.ApplyConfiguration(contentTypes);
+                builder.ApplyConfiguration(publishers);
+                builder.ApplyConfiguration(genres);
+                builder.ApplyConfiguration(books);
+                builder.ApplyConfiguration(bookAuthors);
+                builder.ApplyConfiguration(bookGenres);
+                builder.ApplyConfiguration(users);
+            }
             #endregion
         }
     }

--- a/PubHub/PubHub.API/PubHub.API.csproj
+++ b/PubHub/PubHub.API/PubHub.API.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />

--- a/PubHub/PubHub.Common/Services/PublisherService.cs
+++ b/PubHub/PubHub.Common/Services/PublisherService.cs
@@ -20,7 +20,7 @@ namespace PubHub.Common.Services
             _serializerOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = true,
+                WriteIndented = true
             };
         }
 

--- a/PubHub/PubHub.sln
+++ b/PubHub/PubHub.sln
@@ -13,6 +13,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PubHub.AdminPortal", "PubHu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PubHub.BookMobile", "PubHub.BookMobile\PubHub.BookMobile.csproj", "{D88D1AC5-EA77-46D8-95ED-2F3D606E803F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PubHub.API.UT", "..\Test\PubHub.API.UT\PubHub.API.UT.csproj", "{B2A1C344-9D6D-4C1E-8D3B-B584E8611798}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PubHub.Common.UT", "..\Test\PubHub.Common.UT\PubHub.Common.UT.csproj", "{D1766227-4F71-4FE2-806E-1DB6E4497A0B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PubHub.TestUtils", "..\Test\PubHub.TestUtils\PubHub.TestUtils.csproj", "{9226A806-2F2A-491C-B9E7-5FD383F5C392}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +47,18 @@ Global
 		{D88D1AC5-EA77-46D8-95ED-2F3D606E803F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D88D1AC5-EA77-46D8-95ED-2F3D606E803F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D88D1AC5-EA77-46D8-95ED-2F3D606E803F}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{B2A1C344-9D6D-4C1E-8D3B-B584E8611798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2A1C344-9D6D-4C1E-8D3B-B584E8611798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2A1C344-9D6D-4C1E-8D3B-B584E8611798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2A1C344-9D6D-4C1E-8D3B-B584E8611798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1766227-4F71-4FE2-806E-1DB6E4497A0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1766227-4F71-4FE2-806E-1DB6E4497A0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1766227-4F71-4FE2-806E-1DB6E4497A0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1766227-4F71-4FE2-806E-1DB6E4497A0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9226A806-2F2A-491C-B9E7-5FD383F5C392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9226A806-2F2A-491C-B9E7-5FD383F5C392}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9226A806-2F2A-491C-B9E7-5FD383F5C392}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9226A806-2F2A-491C-B9E7-5FD383F5C392}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Test/PubHub.API.UT/Controllers/ControllerTests.cs
+++ b/Test/PubHub.API.UT/Controllers/ControllerTests.cs
@@ -1,0 +1,25 @@
+﻿using AutoFixture;
+using PubHub.API.UT.Utilities;
+
+namespace PubHub.API.UT.Controllers
+{
+    public abstract class ControllerTests : IClassFixture<DatabaseFixture>, IClassFixture<ApiDataGeneratorFixture>, IAsyncLifetime
+    {
+        protected ControllerTests(DatabaseFixture databaseFixture, ApiDataGeneratorFixture apiDataGeneratorFixture)
+        {
+            DatabaseFixture = databaseFixture;
+            Fixture = apiDataGeneratorFixture.Generator;
+        }
+
+        protected DatabaseFixture DatabaseFixture { get; }
+        protected PubHubContext Context => DatabaseFixture.Context;
+        protected Fixture Fixture { get; }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        async Task IAsyncLifetime.DisposeAsync()
+        {
+            await DatabaseFixture.CleanUpAsync();
+        }
+    }
+}

--- a/Test/PubHub.API.UT/Controllers/PublishersControllerTests.cs
+++ b/Test/PubHub.API.UT/Controllers/PublishersControllerTests.cs
@@ -1,0 +1,89 @@
+﻿using AutoFixture;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PubHub.API.Controllers;
+using PubHub.API.Domain.Entities;
+using PubHub.API.UT.Extensions;
+using PubHub.API.UT.Utilities;
+using PubHub.Common.Models.Publishers;
+using PubHub.TestUtils.Extensions;
+
+namespace PubHub.API.UT.Controllers
+{
+    public class PublishersControllerTests : ControllerTests
+    {
+        private readonly PublishersController _controller;
+
+        public PublishersControllerTests(DatabaseFixture databaseFixture, ApiDataGeneratorFixture apiDataGeneratorFixture)
+            : base(databaseFixture, apiDataGeneratorFixture)
+        {
+            _controller = new(Substitute.For<ILogger<PublishersController>>(), Context);
+        }
+
+        //[Fact]
+        //TODO (SIA): This test currently fails with unknown account type.
+        public async Task AddPublisherAsync()
+        {
+            // Arrange.
+            var publisher = Fixture.Create<PublisherCreateModel>();
+
+            // Act.
+            var result = await _controller.AddPublisherAsync(publisher);
+
+            // Assert.
+            var response = Assert.IsAssignableFrom<Created<PublisherInfoModel>>(result);
+            Assert.NotNull(response.Value);
+
+            Context.AssertCreated(publisher, response.Value.Id);
+        }
+
+        [Fact]
+        public async Task GetPublisherByIdAsync()
+        {
+            // Arrange.
+            var publishers = Fixture.CreateMany<Publisher>(10);
+            await Context.Set<Publisher>().AddRangeAsync(publishers);
+            await Context.SaveChangesAsync();
+
+            var expectedPublisher = publishers.Random();
+            var expectedModel = expectedPublisher.ToInfo();
+
+            // Act.
+            var result = await _controller.GetPublisherAsync(expectedPublisher.Id);
+
+            // Assert.
+            var response = Assert.IsAssignableFrom<Ok<PublisherInfoModel>>(result);
+            Assert.NotNull(response.Value);
+            Assert.Equivalent(expectedModel, response.Value);
+        }
+
+        [Fact]
+        public async Task GetAllPublishersAsync()
+        {
+            // Arrange.
+            int publisherCount = 15;
+            var publishers = Fixture.CreateMany<Publisher>(publisherCount);
+            await Context.Set<Publisher>().AddRangeAsync(publishers);
+            await Context.SaveChangesAsync();
+
+            var expectedModels = publishers.ToInfo().ToList();
+
+            var query = new PublisherQuery()
+            {
+                Max = int.MaxValue,
+                Page = 1
+            };
+
+            // Act.
+            var result = await _controller.GetPublishersAsync(query);
+
+            // Assert.
+            var response = Assert.IsAssignableFrom<Ok<PublisherInfoModel[]>>(result);
+            Assert.NotNull(response.Value);
+            Assert.Equal(expectedModels.Count, response.Value.Length);
+            Assert.Equivalent(expectedModels, response.Value);
+        }
+    }
+}

--- a/Test/PubHub.API.UT/Extensions/ContextExtensions.cs
+++ b/Test/PubHub.API.UT/Extensions/ContextExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore;
+using PubHub.API.Domain.Entities;
+using PubHub.Common.Models.Publishers;
+
+namespace PubHub.API.UT.Extensions
+{
+    public static class ContextExtensions
+    {
+        /// <summary>
+        /// Assert that a publisher has been created correctly from a given <see cref="PublisherCreateModel"/>.
+        /// </summary>
+        /// <param name="id">ID of publisher.</param>
+        public static void AssertCreated(this PubHubContext context, PublisherCreateModel publisher, Guid id)
+        {
+            // Get created publisher from database.
+            var actualPublishers = context.Set<Publisher>()
+                .Include(p => p.Account)
+                .Where(p => p.Id == id)
+                .ToList();
+            var actualPublisher = Assert.Single(actualPublishers);
+
+            // Assert properties of actual publisher.
+            Assert.Equal(publisher.Name, actualPublisher.Name);
+            Assert.NotNull(actualPublisher.Account);
+            Assert.Equal(publisher.Account.Email, actualPublisher.Account.Email);
+            Assert.False(string.IsNullOrWhiteSpace(actualPublisher.Account.PasswordHash));
+        }
+    }
+}

--- a/Test/PubHub.API.UT/Extensions/EntityExtensions.cs
+++ b/Test/PubHub.API.UT/Extensions/EntityExtensions.cs
@@ -1,0 +1,20 @@
+﻿using PubHub.API.Domain.Entities;
+using PubHub.Common.Models.Publishers;
+
+namespace PubHub.API.UT.Extensions
+{
+    internal static class EntityExtensions
+    {
+        #region Publisher
+        public static PublisherInfoModel ToInfo(this Publisher publisher) => new()
+        {
+            Id = publisher.Id,
+            Name = publisher.Name,
+            Email = publisher.Account!.Email
+        };
+
+        public static IEnumerable<PublisherInfoModel> ToInfo(this IEnumerable<Publisher> publishers) =>
+            publishers.Select(ToInfo);
+        #endregion
+    }
+}

--- a/Test/PubHub.API.UT/GlobalUsings.cs
+++ b/Test/PubHub.API.UT/GlobalUsings.cs
@@ -1,0 +1,3 @@
+﻿global using Xunit;
+global using PubHub.API.Domain;
+global using PubHub.TestUtils;

--- a/Test/PubHub.API.UT/PubHub.API.UT.csproj
+++ b/Test/PubHub.API.UT/PubHub.API.UT.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Respawn" Version="6.2.1" />
+    <PackageReference Include="Testcontainers.MsSql" Version="3.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.11.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PubHub\PubHub.API\PubHub.API.csproj" />
+    <ProjectReference Include="..\PubHub.TestUtils\PubHub.TestUtils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Test/PubHub.API.UT/Utilities/ApiDataGeneratorFixture.cs
+++ b/Test/PubHub.API.UT/Utilities/ApiDataGeneratorFixture.cs
@@ -1,0 +1,17 @@
+﻿using PubHub.API.Domain.Entities;
+using PubHub.API.Domain.Identity;
+
+namespace PubHub.API.UT.Utilities
+{
+    public class ApiDataGeneratorFixture : DataGeneratorFixture
+    {
+        public ApiDataGeneratorFixture() : base()
+        {
+            Generator.Customize<Publisher>(x => x
+                .Without(p => p.AccountId)
+                .Without(p => p.Books));
+            Generator.Customize<Account>(x => x
+                .With(a => a.DeletedDate, (DateTime?)null));
+        }
+    }
+}

--- a/Test/PubHub.API.UT/Utilities/DatabaseFixture.cs
+++ b/Test/PubHub.API.UT/Utilities/DatabaseFixture.cs
@@ -1,0 +1,102 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Respawn;
+using Testcontainers.MsSql;
+
+namespace PubHub.API.UT.Utilities
+{
+    public class DatabaseFixture : IAsyncLifetime
+    {
+        private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder().Build();
+
+        /// <summary>
+        /// Whether the <see cref="DatabaseFixture"/> has been configured correctly.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        [MemberNotNullWhen(true, nameof(_connection))]
+        [MemberNotNullWhen(true, nameof(_respawner))]
+        private bool IsConfigured
+        {
+            get
+            {
+                if (_connection != null && _respawner != null)
+                {
+                    return true;
+                }
+
+                throw new InvalidOperationException($"{nameof(DatabaseFixture)} wasn't configured correctly.");
+            }
+        }
+
+        private DbContextOptions<PubHubContext> _options = new();
+        private SqlConnection? _connection;
+        private PubHubContext? _context;
+        private Respawner? _respawner;
+
+        /// <summary>
+        /// Database context to the current test database.
+        /// </summary>
+        public PubHubContext Context => _context ??= new PubHubContext(_options) { ApplySeed = false };
+
+        public async Task InitializeAsync()
+        {
+            await _msSqlContainer.StartAsync();
+            await CreateDatabaseAsync();
+            await ConfigureRespawner();
+        }
+
+        /// <summary>
+        /// Clean up the database after a test.
+        /// </summary>
+        public async Task CleanUpAsync()
+        {
+            if (IsConfigured)
+            {
+                await _respawner.ResetAsync(_connection);
+            }
+        }
+
+        /// <summary>
+        /// Connect to Docker container and create the database.
+        /// </summary>
+        private async Task CreateDatabaseAsync()
+        {
+            // Connect to database container.
+            string connectionString = _msSqlContainer.GetConnectionString() + ";Persist Security Info=true";
+            _connection ??= new(connectionString);
+            await _connection.OpenAsync();
+
+            // Create options.
+            _options = new DbContextOptionsBuilder<PubHubContext>()
+                .UseSqlServer(_connection)
+                .Options;
+
+            // Build database schema.
+            await Context.Database.EnsureCreatedAsync();
+        }
+
+        /// <summary>
+        /// Create delete script for reseting.
+        /// </summary>
+        /// <exception cref="NullReferenceException"><see cref="_connection"/> was null.</exception>
+        private async Task ConfigureRespawner()
+        {
+            if (_connection == null)
+            {
+                throw new NullReferenceException("Connection was null when trying to configure Respawner.");
+            }
+
+            _respawner = await Respawner.CreateAsync(_connection, new()
+            {
+                DbAdapter = DbAdapter.SqlServer
+            });
+        }
+
+        async Task IAsyncLifetime.DisposeAsync()
+        {
+            // Remove the Docker container.
+            await _msSqlContainer.DisposeAsync();
+        }
+    }
+}

--- a/Test/PubHub.Common.UT/GlobalUsings.cs
+++ b/Test/PubHub.Common.UT/GlobalUsings.cs
@@ -1,0 +1,2 @@
+﻿global using Xunit;
+global using PubHub.TestUtils;

--- a/Test/PubHub.Common.UT/PubHub.Common.UT.csproj
+++ b/Test/PubHub.Common.UT/PubHub.Common.UT.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PubHub\PubHub.Common\PubHub.Common.csproj" />
+    <ProjectReference Include="..\PubHub.TestUtils\PubHub.TestUtils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Test/PubHub.Common.UT/Services/PublisherServiceTests.cs
+++ b/Test/PubHub.Common.UT/Services/PublisherServiceTests.cs
@@ -1,0 +1,37 @@
+﻿using AutoFixture;
+using NSubstitute;
+using PubHub.Common.Models.Publishers;
+using PubHub.Common.Services;
+
+namespace PubHub.Common.UT.Services
+{
+    public class PublisherServiceTests : ServiceTests
+    {
+        private readonly PublisherService _service;
+        private readonly IHttpClientService _client;
+
+        public PublisherServiceTests(DataGeneratorFixture dataGeneratorFixture)
+            : base(dataGeneratorFixture)
+        {
+            _client = Substitute.For<IHttpClientService>();
+            _service = new(_client);
+        }
+
+        [Fact]
+        public async Task GetPublisherByIdAsync()
+        {
+            // Arrange.
+            var expectedModel = Generator.Create<PublisherInfoModel>();
+            _client.GetAsync(Arg.Any<string>()).Returns(Task.FromResult(new HttpResponseMessage()
+            {
+                Content = GetJsonContent(expectedModel)
+            }));
+
+            // Act.
+            var actualModel = await _service.GetPublisherInfo(expectedModel.Id);
+
+            // Assert.
+            Assert.Equivalent(expectedModel, actualModel);
+        }
+    }
+}

--- a/Test/PubHub.Common.UT/Services/ServiceTests.cs
+++ b/Test/PubHub.Common.UT/Services/ServiceTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Text;
+using System.Text.Json;
+using AutoFixture;
+
+namespace PubHub.Common.UT.Services
+{
+    public abstract class ServiceTests : IClassFixture<DataGeneratorFixture>
+    {
+        private readonly JsonSerializerOptions _serializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+
+        public ServiceTests(DataGeneratorFixture dataGeneratorFixture)
+        {
+            Generator = dataGeneratorFixture.Generator;
+        }
+
+        protected Fixture Generator { get; }
+
+        public StringContent GetJsonContent(object obj) =>
+            new(JsonSerializer.Serialize(obj, _serializerOptions), Encoding.UTF8, "application/json");
+    }
+}

--- a/Test/PubHub.TestUtils/DataGeneratorFixture.cs
+++ b/Test/PubHub.TestUtils/DataGeneratorFixture.cs
@@ -1,0 +1,23 @@
+﻿using AutoFixture;
+
+namespace PubHub.TestUtils
+{
+    public class DataGeneratorFixture
+    {
+        public Fixture Generator { get; private set; }
+
+        public DataGeneratorFixture()
+        {
+            Generator = new Fixture();
+
+            Generator.Behaviors.Remove(new ThrowingRecursionBehavior());
+            Generator.Behaviors.Add(new OmitOnRecursionBehavior());
+
+            // Add support for otherwise unsupported types.
+            Generator.Customize<DateOnly>(composer => composer.FromFactory<DateTime>(DateOnly.FromDateTime));
+
+            // Model customizations.
+            // None at the moment...
+        }
+    }
+}

--- a/Test/PubHub.TestUtils/Extensions/CollectionExtensions.cs
+++ b/Test/PubHub.TestUtils/Extensions/CollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace PubHub.TestUtils.Extensions
+{
+    public static class CollectionExtensions
+    {
+        private static readonly Random _rnd = new();
+
+        /// <summary>
+        /// Return a random element from <paramref name="items"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of item.</typeparam>
+        /// <param name="items">Collection of items.</param>
+        /// <returns>Random item from <paramref name="items"/>.</returns>
+        public static T Random<T>(this IEnumerable<T> items) =>
+            items.ElementAt(_rnd.Next(0, items.Count()));
+
+        /// <inheritdoc cref="Random"/>
+        public static T Random<T>(this IList<T> items) =>
+            items[_rnd.Next(0, items.Count)];
+    }
+}

--- a/Test/PubHub.TestUtils/PubHub.TestUtils.csproj
+++ b/Test/PubHub.TestUtils/PubHub.TestUtils.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PubHub\PubHub.Common\PubHub.Common.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Added project `PubHub.API.UT` for unit testing of the API.
- Added project `PubHub.Common.UT` for unit testing of the common library.
- Added project `PubHub.TestUtils` for extensions and fixtures relavant for all tests (incl. future function tests).
- A few tests that we can use as reference for more.
- Database seeding has been made optional to not conflict with tests.

I've done my best to make things as simplistic as possible, so that new test methods can be created quickly and only contain a minimal amount of code.

If you are going to run the tests that use the `DatabaseFixture` (all API controller tests), the Docker daemon must be running on the system executing the tests.

Closes #91.