### PR TITLE
Fix and improve access service and results

### DIFF
--- a/PubHub/PubHub.API/Controllers/AuthController.cs
+++ b/PubHub/PubHub.API/Controllers/AuthController.cs
@@ -51,7 +51,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status422UnprocessableEntity, Type = typeof(ProblemDetails))]
         public async Task<IResult> RegisterUserAsync([FromBody] UserCreateModel userCreateModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessResult))
                 return accessResult;
@@ -176,7 +176,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetTokenAsync([FromBody] LoginInfo loginInfo, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? endpointAccessProblem))
                 return endpointAccessProblem;
@@ -198,8 +198,9 @@ namespace PubHub.API.Controllers
             var account = await _userManager.FindByEmailAsync(loginInfo.Email);
             if (account != null)
             {
-                if (!_accessService.AccessFor(account.AccountTypeId, appId)
+                if (!_accessService.AccessFor(appId, account.AccountTypeId)
                     .CheckWhitelistSubject()
+                    .AllowAny()
                     .TryVerify(out IResult? accountTypeAccessProblem))
                     return accountTypeAccessProblem;
 
@@ -263,9 +264,10 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> RefreshTokenAsync([FromHeader] string authorization, [FromHeader] string refreshToken, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .CheckWhitelistSubject()
+                .AllowAny()
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
 
@@ -410,9 +412,10 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> RevokeTokenAsync([FromHeader] string authorization, [FromHeader] string refreshToken, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .CheckWhitelistSubject()
+                .AllowAny()
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
 

--- a/PubHub/PubHub.API/Controllers/AuthorsController.cs
+++ b/PubHub/PubHub.API/Controllers/AuthorsController.cs
@@ -34,7 +34,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IList<AuthorInfoModel>))]
         public async Task<IResult> GetAuthorsAsync([FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -55,7 +55,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetAuthorAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -86,7 +86,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(AuthorInfoModel))]
         public async Task<IResult> AddAuthorAsync([FromBody] AuthorCreateModel authorModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))
@@ -139,7 +139,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> DeleteAuthorAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))

--- a/PubHub/PubHub.API/Controllers/BooksController.cs
+++ b/PubHub/PubHub.API/Controllers/BooksController.cs
@@ -42,7 +42,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IList<BookInfoModel>))]
         public async Task<IResult> GetBooksAsync([FromQuery] BookQuery queryOptions, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -95,7 +95,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetBookAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -160,7 +160,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
         public async Task<IResult> AddBookAsync([FromBody] BookCreateModel createModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowPublisher(createModel.PublisherId)
                 .AllowOperator()
@@ -324,7 +324,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status422UnprocessableEntity, Type = typeof(ProblemDetails))]
         public async Task<IResult> UpdateBookAsync(Guid id, [FromBody] BookUpdateModel updateModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -344,7 +344,7 @@ namespace PubHub.API.Controllers
                         { "Id", id }
                     });
 
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .AllowPublisher(existingBook.PublisherId)
                 .AllowOperator()
                 .TryVerify(out IResult? subjectAccessProblem))
@@ -490,7 +490,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> DeleteBookAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -508,7 +508,7 @@ namespace PubHub.API.Controllers
                         { "Id", id }
                     });
 
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .AllowPublisher(book.PublisherId)
                 .AllowOperator()
                 .TryVerify(out IResult? subjectAccessProblem))

--- a/PubHub/PubHub.API/Controllers/ContentTypeController.cs
+++ b/PubHub/PubHub.API/Controllers/ContentTypeController.cs
@@ -29,7 +29,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IList<ContentTypeInfoModel>))]
         public async Task<IResult> GetContentTypesAsync([FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;

--- a/PubHub/PubHub.API/Controllers/GenresController.cs
+++ b/PubHub/PubHub.API/Controllers/GenresController.cs
@@ -34,7 +34,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IList<GenreInfoModel>))]
         public async Task<IResult> GetGenresAsync([FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -55,7 +55,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetGenreAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .TryVerify(out IResult? accessProblem))
                 return accessProblem;
@@ -86,7 +86,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(GenreInfoModel))]
         public async Task<IResult> AddGenreAsync([FromBody] GenreCreateModel genreModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))
@@ -137,7 +137,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> DeleteGenreAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))

--- a/PubHub/PubHub.API/Controllers/PublishersController.cs
+++ b/PubHub/PubHub.API/Controllers/PublishersController.cs
@@ -51,7 +51,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         public async Task<IResult> AddPublisherAsync([FromBody] PublisherCreateModel publisherCreateModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))
@@ -156,7 +156,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetPublisherAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowPublisher(id)
                 .AllowOperator()
@@ -184,7 +184,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PublisherInfoModel[]))]
         public async Task<IResult> GetPublishersAsync([FromQuery] PublisherQuery query, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowOperator()
                 .TryVerify(out IResult? accessProblem))
@@ -215,7 +215,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetBooksAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser()
                 .AllowPublisher(id)
@@ -292,7 +292,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> UpdatePublisherAsync(Guid id, [FromBody] PublisherUpdateModel publisherUpdateModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowPublisher(id)
                 .AllowOperator()
@@ -364,7 +364,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> DeletePublisherAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowPublisher(id)
                 .AllowOperator()

--- a/PubHub/PubHub.API/Controllers/UsersController.cs
+++ b/PubHub/PubHub.API/Controllers/UsersController.cs
@@ -49,7 +49,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetUserAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser(id)
                 .AllowOperator()
@@ -81,7 +81,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> GetBooksAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser(id)
                 .AllowOperator()
@@ -161,7 +161,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> UpdateUserAsync(Guid id, [FromBody] UserUpdateModel userUpdateModel, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser(id)
                 .AllowOperator()
@@ -232,7 +232,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         public async Task<IResult> DeleteUserAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser(id)
                 .AllowOperator()
@@ -285,7 +285,7 @@ namespace PubHub.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IResult> SuspendUserAsync(Guid id, [FromHeader] string appId)
         {
-            if (!_accessService.AccessFor(User, appId)
+            if (!_accessService.AccessFor(appId, User)
                 .CheckWhitelistEndpoint(GetType().Name)
                 .AllowUser(id)
                 .AllowOperator()

--- a/PubHub/PubHub.API/Domain/Auth/AccessResult.cs
+++ b/PubHub/PubHub.API/Domain/Auth/AccessResult.cs
@@ -20,7 +20,7 @@ namespace PubHub.API.Domain.Auth
         private string? _subjectName;
         private AppWhitelist? _appWhitelist;
 
-        public AccessResult(ClaimsPrincipal principal, string appId, TypeLookupService typeLookupService, WhitelistOptions whiteListOptions)
+        public AccessResult(string appId, ClaimsPrincipal principal, TypeLookupService typeLookupService, WhitelistOptions whiteListOptions)
         {
             _whiteListOptions = whiteListOptions;
             _appId = appId;
@@ -28,12 +28,18 @@ namespace PubHub.API.Domain.Auth
             TypeLookupService = typeLookupService;
         }
 
-        public AccessResult(Guid accountTypeId, string appId, TypeLookupService typeLookupService, WhitelistOptions whiteListOptions)
+        public AccessResult(string appId, Guid accountTypeId, TypeLookupService typeLookupService, WhitelistOptions whiteListOptions)
         {
             _whiteListOptions = whiteListOptions;
-            _accountTypeId = accountTypeId;
             _appId = appId;
-            Principal = null;
+            _accountTypeId = accountTypeId;
+            TypeLookupService = typeLookupService;
+        }
+
+        public AccessResult(string appId, TypeLookupService typeLookupService, WhitelistOptions whiteListOptions)
+        {
+            _whiteListOptions = whiteListOptions;
+            _appId = appId;
             TypeLookupService = typeLookupService;
         }
 
@@ -42,6 +48,7 @@ namespace PubHub.API.Domain.Auth
 
         public bool Concluded => _success == false;
         public bool Success => _success ?? false;
+        public bool HasSubject => !(Principal == null && AccountTypeId == Guid.Empty);
 
         public Guid AccountTypeId => _accountTypeId ??= Principal?.GetAccountTypeId() ?? Guid.Empty;
         public Guid SubjectId => _subjectId ??= Principal?.GetSubjectId() ?? Guid.Empty;

--- a/PubHub/PubHub.API/Domain/Auth/AccessResultExtensions.cs
+++ b/PubHub/PubHub.API/Domain/Auth/AccessResultExtensions.cs
@@ -69,7 +69,9 @@ namespace PubHub.API.Domain.Auth
                 return accessResult;
             }
 
-            accessResult.Allow();
+            // Allow if not validating subject.
+            if (!accessResult.HasSubject)
+                accessResult.Allow();
 
             return accessResult;
         }
@@ -78,7 +80,7 @@ namespace PubHub.API.Domain.Auth
         /// Check if <see cref="AccessResult.SubjectName"/> is included in the <see cref="AccessResult.AppWhitelist"/>.
         /// </summary>
         /// <param name="accessResult"><see cref="AccessResult"/> to extend.</param>
-        /// <param name="subjectName">Name of subject to use if of <see cref="AccessResult.SubjectName"/> is null.</param>
+        /// <param name="subjectNameFallback">Name of subject to use if <see cref="AccessResult.SubjectName"/> is null.</param>
         /// <returns><paramref name="accessResult"/></returns>
         public static AccessResult CheckWhitelistSubject(this AccessResult accessResult, string? subjectNameFallback = null)
         {
@@ -89,7 +91,9 @@ namespace PubHub.API.Domain.Auth
             if (!(subjectName != null && (accessResult.AppWhitelist?.Subjects.Contains(subjectName) ?? false)))
                 accessResult.Disallow();
 
-            accessResult.Allow();
+            // Allow if not validating subject.
+            if (!accessResult.HasSubject)
+                accessResult.Allow();
 
             return accessResult;
         }
@@ -175,6 +179,22 @@ namespace PubHub.API.Domain.Auth
                 return accessResult;
 
             if (accessResult.TypeLookupService.IsOperator(accessResult.AccountTypeId))
+                accessResult.Allow();
+
+            return accessResult;
+        }
+
+        /// <summary>
+        /// Allow any subject, only superseded by the whitelist.
+        /// </summary>
+        /// <param name="accessResult"><see cref="AccessResult"/> to extend.</param>
+        /// <returns><paramref name="accessResult"/></returns>
+        public static AccessResult AllowAny(this AccessResult accessResult)
+        {
+            if (accessResult.Concluded || accessResult.Success)
+                return accessResult;
+
+            if (accessResult.HasSubject)
                 accessResult.Allow();
 
             return accessResult;

--- a/PubHub/PubHub.API/Domain/Auth/AccessService.cs
+++ b/PubHub/PubHub.API/Domain/Auth/AccessService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Claims;
 using Microsoft.Extensions.Options;
+using PubHub.API.Domain.Entities;
 using PubHub.API.Domain.Services;
 
 namespace PubHub.API.Domain.Auth
@@ -17,17 +18,24 @@ namespace PubHub.API.Domain.Auth
 
         /// <summary>
         /// Create an <see cref="AccessResult"/> ready to apply verification to with allow methods from <see cref="AccessResultExtensions"/>.
-        /// End verification with <see cref="AccessResultExtensions.TryVerify(AccessResult, out IResult?)"/>.
+        /// End verification with <see cref="AccessResultExtensions.TryVerify"/>.
         /// </summary>
-        /// <param name="principal">Subject to verify access for.</param>
         /// <param name="appId">Unique and secret application ID of an application accessing the PubHub API.</param>
+        /// <param name="principal">Subject to verify access for.</param>
+        /// <remarks>
+        /// When checking access for a user or account type one MUST use at least one 'Allow' extension before calling <see cref="AccessResultExtensions.TryVerify"/>.
+        /// <br />Use <see cref="AccessResultExtensions.AllowAny"/> if no additional restrictions should be made for the subject.</remarks>
         /// <returns><see cref="AccessResult"/> for <paramref name="principal"/>.</returns>
-        public AccessResult AccessFor(ClaimsPrincipal principal, string appId) =>
-            new(principal, appId, _typeLookupService, _whitelistOptions);
+        public AccessResult AccessFor(string appId, ClaimsPrincipal principal) =>
+            new(appId, principal, _typeLookupService, _whitelistOptions);
 
-        /// <inheritdoc cref="AccessFor(ClaimsPrincipal, string)"/>
+        /// <inheritdoc cref="AccessFor(string, ClaimsPrincipal)"/>
         /// <param name="accountTypeId">ID of account type to verify access for.</param>
-        public AccessResult AccessFor(Guid accountTypeId, string appId) =>
-            new(accountTypeId, appId, _typeLookupService, _whitelistOptions);
+        public AccessResult AccessFor(string appId, Guid accountTypeId) =>
+            new(appId, accountTypeId, _typeLookupService, _whitelistOptions);
+
+        /// <inheritdoc cref="AccessFor(string, ClaimsPrincipal)"/>
+        public AccessResult AccessFor(string appId) => 
+            new(appId, _typeLookupService, _whitelistOptions);
     }
 }


### PR DESCRIPTION
I discovered that the chain of `AccessResult` could produce false positives when the application has access to an endpoint but the the given user hasn't. I've corrected the issues here, by only allowing whe `CheckWhitelist` methods to produce a success, if no subject (user or account type ID) has been given in `AccessFor()` (where the `AccessResult` is created).

**Difference in usage:** It is now required to use at least one 'Allow' method in the chain, _when_ a user or account type ID is specified in `AccessFor()`.