### PR TITLE
Enabling encryption on communication

### DIFF
--- a/PubHub/PubHub.API/Program.cs
+++ b/PubHub/PubHub.API/Program.cs
@@ -45,9 +45,19 @@ builder.Services.Configure<ApiBehaviorOptions>(options =>
     };
 });
 
+builder.Services.AddHsts(options =>
+{
+    options.MaxAge = TimeSpan.FromDays(365);    // Long-term security assurance and reduced vulnerability window.
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts(); // Enable HSTS middleware for non-development environments
+}
+
 if (app.Environment.IsDevelopment())
     app.UseDeveloperExceptionPage();
 

--- a/PubHub/PubHub.AdminPortal/Program.cs
+++ b/PubHub/PubHub.AdminPortal/Program.cs
@@ -50,6 +50,11 @@ builder.Services.AddAuthentication(options =>
     options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
 });
 
+builder.Services.AddHsts(options =>
+{ 
+    options.MaxAge = TimeSpan.FromDays(365);    // Long-term security assurance and reduced vulnerability window.
+});
+
 builder.Services.AddRadzenComponents();
 builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<FileHandler>();


### PR DESCRIPTION
Closes #14 

- Added the Hsts configuration to both the admin portal and the api projects. 
- Tested that the admin portal redirects to use https when testing the http url in launchSettings.json.

We’ve set up for the application to use HSTS in production but, because of the [official documentation](https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-3.0&tabs=visual-studio%2Clinux-ubuntu#http-strict-transport-security-protocol-hsts-1), we’d have to put the environment to production to test if the header Strict-Transport-Security shows up in the network tab of the devtools - so this haven’t been done, due to the state of the project being a prototype.

Added documentation on the matter [here](https://docs.google.com/document/d/1LtJKy3JLAMPYglDSLVlHU5Js0ycNd-HI4G2w6CU5bJ0/edit#bookmark=id.d49ei2hvw3b4).