### PR TITLE
Update polly retry policy

### DIFF
--- a/PubHub/PubHub.API/Controllers/BooksController.cs
+++ b/PubHub/PubHub.API/Controllers/BooksController.cs
@@ -228,6 +228,7 @@ namespace PubHub.API.Controllers
             return Results.Ok();
         }
 
+        [DisableRequestSizeLimit]
         [HttpPost()]
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(BookInfoModel))]
         [ProducesResponseType(StatusCodes.Status422UnprocessableEntity, Type = typeof(ProblemDetails))]
@@ -392,6 +393,7 @@ namespace PubHub.API.Controllers
             return Results.Created($"books/{bookInfo!.Id}", bookInfo);
         }
 
+        [DisableRequestSizeLimit]
         [HttpPut("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BookInfoModel))]
         [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]

--- a/PubHub/PubHub.Common/Extensions/ServiceExtensions.cs
+++ b/PubHub/PubHub.Common/Extensions/ServiceExtensions.cs
@@ -127,7 +127,7 @@ namespace PubHub.Common.Extensions
                     {
                         TimeoutGenerator = static args =>
                         {
-                            var contentMegabytes = args.Context.Properties.GetValue(new(ResilienceConstants.CONTENT_MEGABYTES_RESILIENCE_KEY), 0d);
+                            var contentMegabytes = args.Context.Properties.GetValue(new(ResilienceConstants.CONTENT_MEGABYTES_RESILIENCE_KEY), (decimal)0);
                             double timeoutSeconds = 30;
                             if (contentMegabytes >= 2)
                             {

--- a/PubHub/PubHub.Common/ResilienceConstants.cs
+++ b/PubHub/PubHub.Common/ResilienceConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace PubHub.Common
+{
+    internal class ResilienceConstants
+    {
+        public const string CONTENT_MEGABYTES_RESILIENCE_KEY = "size";
+    }
+}

--- a/PubHub/PubHub.Common/Services/HttpClientService.cs
+++ b/PubHub/PubHub.Common/Services/HttpClientService.cs
@@ -1,6 +1,7 @@
 ﻿using Polly;
 using PubHub.Common.Models.Authentication;
 using System.Net.Mime;
+using System.Text;
 
 namespace PubHub.Common.Services
 {
@@ -116,7 +117,8 @@ namespace PubHub.Common.Services
             var context = ResilienceContextPool.Shared.Get();
             if (!string.IsNullOrWhiteSpace(content))
             {
-                context.Properties.Set(new(ResilienceConstants.CONTENT_MEGABYTES_RESILIENCE_KEY), content?.Length * 0.000001 * sizeof(char) ?? 0d);
+                var megabytes = (decimal)Encoding.UTF8.GetByteCount(content) / 1048576;
+                context.Properties.Set(new(ResilienceConstants.CONTENT_MEGABYTES_RESILIENCE_KEY), megabytes);
             }
 
             return context;

--- a/PubHub/PubHub.Common/Services/HttpClientService.cs
+++ b/PubHub/PubHub.Common/Services/HttpClientService.cs
@@ -1,6 +1,5 @@
 ﻿using Polly;
 using PubHub.Common.Models.Authentication;
-using System.Diagnostics;
 using System.Net.Mime;
 
 namespace PubHub.Common.Services
@@ -17,6 +16,7 @@ namespace PubHub.Common.Services
         {
             _client = client;
             _client.DefaultRequestHeaders.Add("refreshToken", string.Empty);
+            _client.Timeout = TimeSpan.Parse("24.20:31:23.6470000"); // Polly will take care of timeout.
             _resiliencePipeline = resiliencePipeline;
             _tokenInfoAsync = tokenInfoAsync;
         }
@@ -26,31 +26,33 @@ namespace PubHub.Common.Services
         {
             CheckNetwork();
 
-            return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
+            var context = StartRequest();
+            var response = await _resiliencePipeline.ExecuteAsync(async context =>
             {
-                var tokenInfo = await _tokenInfoAsync.Invoke();
-                _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(BEARER_KEY, tokenInfo.Token);                    
-                _client.DefaultRequestHeaders.Remove("refreshToken"); 
-                _client.DefaultRequestHeaders.Add("refreshToken", tokenInfo.RefreshToken);
+                await SetTokensAsync();
 
-                return await _client.GetAsync(uri, cancellationToken);
-            });
+                return await _client.GetAsync(uri, context.CancellationToken);
+            }, context);
+            EndRequest(context);
+
+            return response;
         }
 
         /// <inheritdoc/>
         public async Task<HttpResponseMessage> PostAsync(string uri, string? content = null)
         {
-            CheckNetwork();            
+            CheckNetwork();
 
-            return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
+            var context = StartRequest(content);
+            var response = await _resiliencePipeline.ExecuteAsync(async context =>
             {
-                var tokenInfo = await _tokenInfoAsync.Invoke();
-                _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(BEARER_KEY, tokenInfo.Token);
-                _client.DefaultRequestHeaders.Remove("refreshToken");
-                _client.DefaultRequestHeaders.Add("refreshToken", tokenInfo.RefreshToken);
+                await SetTokensAsync();
 
-                return await _client.PostAsync(uri, new StringContent(content ?? string.Empty, System.Text.Encoding.UTF8, MediaTypeNames.Application.Json), cancellationToken);
-            });
+                return await _client.PostAsync(uri, new StringContent(content ?? string.Empty, System.Text.Encoding.UTF8, MediaTypeNames.Application.Json), context.CancellationToken);
+            }, context);
+            EndRequest(context);
+
+            return response;
         }
 
         /// <inheritdoc/>
@@ -58,15 +60,16 @@ namespace PubHub.Common.Services
         {
             CheckNetwork();
 
-            return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
+            var context = StartRequest(content);
+            var response = await _resiliencePipeline.ExecuteAsync(async context =>
             {
-                var tokenInfo = await _tokenInfoAsync.Invoke();
-                _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(BEARER_KEY, tokenInfo.Token);
-                _client.DefaultRequestHeaders.Remove("refreshToken");
-                _client.DefaultRequestHeaders.Add("refreshToken", tokenInfo.RefreshToken);
+                await SetTokensAsync();
 
-                return await _client.PutAsync(uri, new StringContent(content ?? string.Empty, System.Text.Encoding.UTF8, MediaTypeNames.Application.Json), cancellationToken);
-            });
+                return await _client.PutAsync(uri, new StringContent(content ?? string.Empty, System.Text.Encoding.UTF8, MediaTypeNames.Application.Json), context.CancellationToken);
+            }, context);
+            EndRequest(context);
+
+            return response;
         }
 
         /// <inheritdoc/>
@@ -74,15 +77,16 @@ namespace PubHub.Common.Services
         {
             CheckNetwork();
 
-            return await _resiliencePipeline.ExecuteAsync(async cancellationToken =>
+            var context = StartRequest();
+            var response = await _resiliencePipeline.ExecuteAsync(async context =>
             {
-                var tokenInfo = await _tokenInfoAsync.Invoke();
-                _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(BEARER_KEY, tokenInfo.Token);
-                _client.DefaultRequestHeaders.Remove("refreshToken");
-                _client.DefaultRequestHeaders.Add("refreshToken", tokenInfo.RefreshToken);
+                await SetTokensAsync();
 
-                return await _client.DeleteAsync(uri, cancellationToken);
-            });
+                return await _client.DeleteAsync(uri, context.CancellationToken);
+            }, context);
+            EndRequest(context);
+
+            return response;
         }
 
         /// <summary>
@@ -100,6 +104,42 @@ namespace PubHub.Common.Services
                 throw new Exception("No network access;");
             }
 #endif
+        }
+
+        /// <summary>
+        /// Call before executing Polly pipeline.
+        /// </summary>
+        /// <param name="content">Content of HTTP request.</param>
+        /// <returns>Polly <see cref="ResilienceContext"/> from <see cref="ResilienceContextPool"/>.</returns>
+        private static ResilienceContext StartRequest(string? content = null)
+        {
+            var context = ResilienceContextPool.Shared.Get();
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                context.Properties.Set(new(ResilienceConstants.CONTENT_MEGABYTES_RESILIENCE_KEY), content?.Length * 0.000001 * sizeof(char) ?? 0d);
+            }
+
+            return context;
+        }
+
+        /// <summary>
+        /// Call after executing Polly pipeline.
+        /// </summary>
+        /// <param name="context">Polly <see cref="ResilienceContext"/> to put back in the <see cref="ResilienceContextPool"/>. Recommended, but not required.</param>
+        private static void EndRequest(ResilienceContext context)
+        {
+            ResilienceContextPool.Shared.Return(context);
+        }
+
+        /// <summary>
+        /// Set access and refresh tokens on the current <see cref="_client"/>.
+        /// </summary>
+        private async Task SetTokensAsync()
+        {
+            var tokenInfo = await _tokenInfoAsync.Invoke();
+            _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(BEARER_KEY, tokenInfo.Token);
+            _client.DefaultRequestHeaders.Remove("refreshToken");
+            _client.DefaultRequestHeaders.Add("refreshToken", tokenInfo.RefreshToken);
         }
     }
 }


### PR DESCRIPTION
- Only retry on 404, 500 and if no response.
- Do retries faster.
- Added long timeout of 5 min. if the content of an `HttpRequestMessage` is larger than 2 MB. This should address the timeout issue of #144.
- Unlimited size limit on endpoints taking book content. **The database is very slow after the content has been uploaded however. We should really consider switching to file based storage for book content.**

Closes #174.

We could still add more Polly strategies and fallback values for book content and images etc. This, however, won't be happening for the POC.