### PR TITLE
Terminate publishers

### DIFF
--- a/PubHub/PubHub.AdminPortal/Components/Pages/ManagePublishers.razor
+++ b/PubHub/PubHub.AdminPortal/Components/Pages/ManagePublishers.razor
@@ -29,6 +29,7 @@
                             <tr>
                                 <th scope="col">Name</th>
                                 <th scope="col">Email</th>
+                                <th scope="col">Administration</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -37,11 +38,23 @@
                                 <tr>
                                     <td>@publisher.Name</td>
                                     <td>@publisher.Email</td>
+                                    <td>
+                                        <div class="combined-item">
+                                            @if (!string.IsNullOrWhiteSpace(publisher.Email))
+                                            {
+                                                <button class="btn btn-danger" @onclick="() => OpenRemoveModal(publisher)">Remove account</button>
+                                            }
+                                        </div>
+                                    </td>
                                 </tr>
                             }
                         </tbody>
                     </table>
                 </div>
+                @if (showRemoveModal && publisher != null)
+                {
+                    <RemovePublisherModal OnClose="() => OnRemoveDialogClose()" PublisherId="@publisher.Id" PublisherName="@publisher.Name"></RemovePublisherModal>
+                }
             </div>
         }
     </Authorized>
@@ -52,9 +65,12 @@
 
 @code {
     bool showCreateModal;
+    bool showRemoveModal;
     public EventCallback<bool> OnClose { get; set; }
 
     private List<PublisherInfoModel>? Publishers { get; set; }
+
+    private PublisherInfoModel? publisher;
 
     private PublisherQuery publisherQuery = new() { OrderBy = OrderPublisherBy.Name, Descending = true, Max = 10, Page = 1, SearchKey = string.Empty };
 
@@ -67,10 +83,26 @@
         }
     }
 
+    public void OpenRemoveModal(PublisherInfoModel publisherInfo)
+    {
+        publisher = publisherInfo;
+        if (publisher != null)
+        {
+            showRemoveModal = true;
+        }
+    }
+
     #region Dialog closing methods.
     private async Task OnCreateDialogClose()
     {
         showCreateModal = false;
+        await OnInitializedAsync();
+        StateHasChanged();
+    }
+
+    private async Task OnRemoveDialogClose()
+    {
+        showRemoveModal = false;
         await OnInitializedAsync();
         StateHasChanged();
     }

--- a/PubHub/PubHub.AdminPortal/Components/Pages/Modals/Publisher/CreatePublisherModal.razor
+++ b/PubHub/PubHub.AdminPortal/Components/Pages/Modals/Publisher/CreatePublisherModal.razor
@@ -34,7 +34,7 @@
                         <ValidationMessage For="@(() => publisherCreateForm.ConfirmPassword)" />
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-success" @onclick="() => CreatePublisher()">Create</button>
+                        <button type="submit" class="btn btn-success">Create</button>
                         <button type="button" class="btn btn-danger" @onclick="() => ModalOptions(false)">Cancel</button>
                     </div>
                 </div>

--- a/PubHub/PubHub.AdminPortal/Components/Pages/Modals/Publisher/RemovePublisherModal.razor
+++ b/PubHub/PubHub.AdminPortal/Components/Pages/Modals/Publisher/RemovePublisherModal.razor
@@ -1,0 +1,61 @@
+﻿@inject PubHub.Common.Services.IPublisherService PublisherService
+@inject Radzen.NotificationService NotificationService
+@inject Radzen.DialogService DialogService
+
+<div class="modal fade show" id="removePublisherModal" style="display:block; background-color: rgba(10,10,10,.8);"
+     aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">You're about to remove: <b>@PublisherName</b></h4>
+                <button type="button" class="btn close" @onclick="() => ModalOptions(false)">x</button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group mb-2">
+                    <label for="removePublisherNameInput" class="form-label">Are you sure you wish to delete this publisher: <b>@PublisherName</b>?</label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" @onclick="() => RemovePublisher()">Remove</button>
+                <button type="button" class="btn btn-success" @onclick="() => ModalOptions(false)">Cancel</button>
+                @if (unsuccessfulResult)
+                {
+                    <label class="text-danger">Unable to remove the book.</label>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public EventCallback<bool> OnClose { get; set; }
+
+    [Parameter]
+    public Guid PublisherId { get; set; }
+
+    [Parameter]
+    public required string PublisherName { get; set; }
+
+    private bool unsuccessfulResult = false;
+
+    private async Task RemovePublisher()
+    {
+        var result = await PublisherService.DeletePublisherAsync(PublisherId);
+        if (result.StatusCode == ResponseCodeConstants.OK_CODE)
+        {
+            NotificationService.Notify(new Radzen.NotificationMessage { Severity = Radzen.NotificationSeverity.Success, Summary = $"Successfully removed the publisher: {PublisherName}.", Detail = "Success", Duration = 5000 });
+            await ModalOptions(false);
+        }
+        else
+        {
+            NotificationService.Notify(new Radzen.NotificationMessage { Severity = Radzen.NotificationSeverity.Success, Summary = "Unable to remove the publisher.", Detail = "Success", Duration = 5000 });
+            unsuccessfulResult = true;
+        }
+    }
+
+    Task ModalOptions(bool IsClosing)
+    {
+        return OnClose.InvokeAsync(IsClosing);
+    }
+}

--- a/PubHub/PubHub.AdminPortal/appsettings.json
+++ b/PubHub/PubHub.AdminPortal/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*",
   "ApiEndpoint": "https://localhost:7097/",
   "AppId": "adminportal_f9550d49-bc24-4c5f-a88d-ef493cfb3901",
-  "Operator": "2238AFEA-DFAA-8A5F-85C6-018ED3903C8F",
-  "Publisher": "5B821ED6-5250-85DD-85C5-018ED3903C8F"
+  "Operator": "E679CD12-4246-8CA8-85A7-018ED1F63358",
+  "Publisher": "DE29BD14-EF23-8DDE-85A6-018ED1F63358"
 }


### PR DESCRIPTION
Closes #21 

- Added a `Remove account` functionality to the overview of publishers.
  - Tested that it works and the publisher won't be linked to the account any longer.
- Put into the [project report](https://docs.google.com/document/d/1LtJKy3JLAMPYglDSLVlHU5Js0ycNd-HI4G2w6CU5bJ0/edit) some suggestions about the discussion of updating accounts; this will not be implemented in the POC due to time limits but, we still want to define this in the requirements and mark it as **not** being a part of the POC.